### PR TITLE
Add Vitest tests for OpenAI provider CLI adapter

### DIFF
--- a/provider-adapters/pai-openai/.gitignore
+++ b/provider-adapters/pai-openai/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/provider-adapters/pai-openai/README.md
+++ b/provider-adapters/pai-openai/README.md
@@ -1,0 +1,25 @@
+# PAI OpenAI Adapter CLI
+
+`pai-openai` is a provider-agnostic CLI wrapper for OpenAI's Responses API. It augments prompts with filesystem context, streams assistant output, and integrates with local tooling via hooks and tool call execution.
+
+## Features
+
+- Attach repository context using glob patterns or piped STDIN.
+- Stream or batch responses, including JSON mode via `--json`.
+- Detects and forwards function/tool calls with exit code `10` for automation.
+- Optional local tool executor (`--tool-exec`) can respond to tool calls automatically.
+- Pre/Post hook commands with environment injection for CI pipelines.
+- Structured logging with configurable verbosity.
+
+## Usage
+
+```bash
+pai-openai [prompt | -f prompt.txt] \
+  [--model gpt-4.1 | --model o3-pro] \
+  [--context 'src/**/*.ts' README.md --stdin] \
+  [--tool-spec tools/schema.json] \
+  [--pre 'scripts/pre.sh' --post 'node scripts/post.js'] \
+  [--json --stream --out result.json]
+```
+
+See `pai-openai --help` for all flags.

--- a/provider-adapters/pai-openai/package.json
+++ b/provider-adapters/pai-openai/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@pai/provider-openai-cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "pai-openai": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx src/cli.ts --help",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "fast-glob": "^3.3.2",
+    "openai": "^4.56.0",
+    "strip-ansi": "^7.1.0",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.7.4",
+    "@types/yargs": "^17.0.32",
+    "eslint": "^9.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.6.3",
+    "vitest": "^1.6.0"
+  }
+}

--- a/provider-adapters/pai-openai/src/adapter.ts
+++ b/provider-adapters/pai-openai/src/adapter.ts
@@ -1,0 +1,152 @@
+import OpenAI from "openai";
+import { log, logError } from "./log";
+import { CallResult, ToolCall } from "./types";
+import { executeTool, loadToolSpecs } from "./tools";
+
+export type CallArgs = {
+  prompt: string;
+  context: string;
+  model: string;
+  jsonMode: boolean;
+  stream: boolean;
+  timeoutMs: number;
+  toolSpecPath?: string;
+  toolExec?: string;
+};
+
+export async function callOpenAI(args: CallArgs): Promise<CallResult> {
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("OPENAI_API_KEY is required");
+  }
+
+  const client = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: process.env.OPENAI_BASE_URL || "https://api.openai.com/v1",
+    timeout: args.timeoutMs
+  });
+
+  const tools = await loadToolSpecs(args.toolSpecPath);
+
+  const baseInput = [
+    {
+      role: "user" as const,
+      content: [
+        { type: "text" as const, text: args.prompt },
+        ...(args.context ? [{ type: "text" as const, text: args.context }] : [])
+      ]
+    }
+  ];
+
+  if (args.stream) {
+    return await handleStream(client, baseInput, tools, args);
+  }
+
+  return await handleNonStream(client, baseInput, tools, args);
+}
+
+async function handleStream(
+  client: OpenAI,
+  input: OpenAI.ResponseCreateParams["input"],
+  tools: OpenAI.ResponseCreateParams["tools"],
+  args: CallArgs
+): Promise<CallResult> {
+  const stream = await client.responses.stream({
+    model: args.model,
+    input,
+    tools,
+    response_format: args.jsonMode ? { type: "json_object" } : undefined
+  });
+
+  let buffer = "";
+  let pendingTool: ToolCall | undefined;
+
+  stream.on("event", event => {
+    if (event.type === "response.output_text.delta" && event.delta) {
+      buffer += event.delta;
+      process.stdout.write(event.delta);
+    }
+    if (event.type === "response.tool_calls.created") {
+      const call = event.tool_calls?.[0];
+      if (call?.function) {
+        pendingTool = {
+          id: call.id,
+          name: call.function.name,
+          arguments: call.function.arguments
+        };
+        log("info", `Tool requested: ${pendingTool.name}`);
+      }
+    }
+  });
+
+  stream.on("error", err => {
+    logError(err);
+  });
+
+  const finalMessage = await stream.finalMessage();
+
+  if (pendingTool) {
+    if (args.toolExec) {
+      const toolOutput = await executeTool(args.toolExec, pendingTool);
+      await stream.submitToolOutputs([
+        {
+          tool_call_id: pendingTool.id,
+          output: toolOutput.output
+        }
+      ]);
+      const followUp = await stream.finalResponse();
+      const finalText = followUp.output_text ?? buffer;
+      process.stdout.write("\n");
+      return { exitCode: 0, text: finalText, needsTool: false };
+    }
+    log("warn", `Tool call required (${pendingTool.name}). Rerun with --tool-exec to satisfy.`);
+    return { exitCode: 10, text: buffer, needsTool: true, tool: pendingTool };
+  }
+
+  const finalText = finalMessage?.output_text ?? buffer;
+  return { exitCode: 0, text: finalText, needsTool: false };
+}
+
+async function handleNonStream(
+  client: OpenAI,
+  input: OpenAI.ResponseCreateParams["input"],
+  tools: OpenAI.ResponseCreateParams["tools"],
+  args: CallArgs
+): Promise<CallResult> {
+  const response = await client.responses.create({
+    model: args.model,
+    input,
+    tools,
+    response_format: args.jsonMode ? { type: "json_object" } : undefined
+  });
+
+  const outputText = response.output_text ?? "";
+  const toolCalls = response.tool_calls ?? [];
+
+  if (toolCalls.length) {
+    const first = toolCalls[0];
+    const pendingTool: ToolCall = {
+      id: first.id,
+      name: first.function.name,
+      arguments: first.function.arguments
+    };
+    if (args.toolExec) {
+      const toolOutput = await executeTool(args.toolExec, pendingTool);
+      const followUp = await client.responses.submitToolOutputs(response.id, {
+        tool_outputs: [
+          {
+            tool_call_id: pendingTool.id,
+            output: toolOutput.output
+          }
+        ]
+      });
+      const final = followUp.output_text ?? "";
+      process.stdout.write(final);
+      return { exitCode: 0, text: final, needsTool: false };
+    }
+    log("warn", `Tool call required (${pendingTool.name}).`);
+    return { exitCode: 10, text: outputText, needsTool: true, tool: pendingTool };
+  }
+
+  process.stdout.write(outputText);
+  return { exitCode: 0, text: outputText, needsTool: false };
+}

--- a/provider-adapters/pai-openai/src/cli.ts
+++ b/provider-adapters/pai-openai/src/cli.ts
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+import { createInterface } from "node:readline";
+import { stdin, stdout } from "node:process";
+import { promises as fs } from "node:fs";
+import { hideBin } from "yargs/helpers";
+import yargs from "yargs";
+import { buildContext } from "./context";
+import { callOpenAI } from "./adapter";
+import { runHook } from "./hooks";
+import { log, logError, setLogLevel } from "./log";
+import { LogLevel } from "./types";
+
+async function readStdin(): Promise<string> {
+  if (stdin.isTTY) return "";
+  const rl = createInterface({ input: stdin, crlfDelay: Infinity });
+  const chunks: string[] = [];
+  for await (const line of rl) {
+    chunks.push(line);
+  }
+  return chunks.join("\n");
+}
+
+async function readPromptFile(file?: string): Promise<string> {
+  if (!file) return "";
+  const content = await fs.readFile(file, "utf8");
+  return content.trimEnd();
+}
+
+async function main() {
+  const argv = await yargs(hideBin(process.argv))
+    .scriptName("pai-openai")
+    .usage("$0 [prompt | --file prompt.txt]")
+    .option("file", {
+      alias: "f",
+      type: "string",
+      describe: "Prompt file path"
+    })
+    .option("context", {
+      type: "array",
+      describe: "File paths or globs to attach as context"
+    })
+    .option("stdin", {
+      type: "boolean",
+      describe: "Treat STDIN as additional context"
+    })
+    .option("model", {
+      type: "string",
+      describe: "Model to use",
+      default: process.env.OPENAI_MODEL || "gpt-4.1"
+    })
+    .option("json", {
+      type: "boolean",
+      describe: "Force JSON-mode output",
+      default: process.env.OPENAI_JSON_MODE !== "false"
+    })
+    .option("stream", {
+      type: "boolean",
+      describe: "Stream tokens to stdout",
+      default: true
+    })
+    .option("tool-spec", {
+      type: "string",
+      describe: "Path to JSON schema describing function tools"
+    })
+    .option("tool-exec", {
+      type: "string",
+      describe: "Executable to resolve tool calls"
+    })
+    .option("pre", {
+      type: "string",
+      describe: "Command to run before request"
+    })
+    .option("post", {
+      type: "string",
+      describe: "Command to run after request"
+    })
+    .option("out", {
+      type: "string",
+      describe: "Write final output to a file"
+    })
+    .option("timeout", {
+      type: "number",
+      describe: "Request timeout in milliseconds",
+      default: Number(process.env.OPENAI_TIMEOUT_MS || 180_000)
+    })
+    .option("log-level", {
+      choices: ["silent", "error", "warn", "info", "debug"] as const,
+      describe: "Override log level"
+    })
+    .option("quiet", {
+      type: "boolean",
+      describe: "Silence logs"
+    })
+    .option("debug", {
+      type: "boolean",
+      describe: "Enable debug logging"
+    })
+    .option("max-context-bytes", {
+      type: "number",
+      describe: "Max bytes for combined context"
+    })
+    .option("max-file-bytes", {
+      type: "number",
+      describe: "Max bytes per context file"
+    })
+    .help()
+    .example("pai-openai 'Summarize repo risks' --context 'src/**/*.ts' README.md --stream", "Stream summary")
+    .example(
+      "git diff | pai-openai --stdin 'Write tests for changed files' --json",
+      "Attach STDIN diff with JSON output"
+    )
+    .example(
+      "pai-openai -f prompts/refactor.md --tool-spec tools/whoami.json --post 'scripts/create-pr.sh'",
+      "Run with tool spec and post hook"
+    )
+    .parseAsync();
+
+  const logLevel = argv.quiet
+    ? "silent"
+    : (argv.logLevel as LogLevel) || (argv.debug ? "debug" : (process.env.OPENAI_LOG_LEVEL as LogLevel) || "info");
+  setLogLevel(logLevel);
+
+  const runId = Date.now().toString(36);
+
+  const promptArg = argv._[0] ? String(argv._[0]) : "";
+  const filePrompt = await readPromptFile(argv.file as string | undefined);
+  const stdinPrompt = argv.stdin ? await readStdin() : "";
+
+  const prompt = promptArg || filePrompt || stdinPrompt;
+
+  if (!prompt) {
+    throw new Error("No prompt provided. Pass an argument, -f file, or supply --stdin.");
+  }
+
+  const useStdinAsContext = Boolean(argv.stdin && (promptArg || filePrompt));
+
+  const contextInput = await buildContext({
+    globs: (argv.context as string[] | undefined) || [],
+    stdinText: useStdinAsContext ? stdinPrompt : undefined,
+    maxTotalBytes: argv.maxContextBytes as number | undefined,
+    maxFileBytes: argv.maxFileBytes as number | undefined
+  });
+
+  if (argv.pre) {
+    await runHook(argv.pre, {
+      PROMPT: prompt,
+      MODEL: argv.model as string,
+      RUN_ID: runId,
+      CONTEXT_PATHS: contextInput.entries.map(e => e.path).join(",")
+    });
+  }
+
+  let callResult: Awaited<ReturnType<typeof callOpenAI>>;
+  try {
+    callResult = await callOpenAI({
+      prompt,
+      context: contextInput.text,
+      model: argv.model as string,
+      jsonMode: Boolean(argv.json),
+      stream: Boolean(argv.stream),
+      timeoutMs: Number(argv.timeout),
+      toolSpecPath: argv["tool-spec"] as string | undefined,
+      toolExec: argv["tool-exec"] as string | undefined
+    });
+  } catch (err) {
+    logError(err);
+    process.exit(1);
+    return;
+  }
+
+  if (argv.out && callResult.text) {
+    await fs.writeFile(argv.out as string, callResult.text, "utf8");
+    log("info", `Wrote output to ${argv.out}`);
+  }
+
+  if (argv.post) {
+    await runHook(argv.post, {
+      PROMPT: prompt,
+      MODEL: argv.model as string,
+      RUN_ID: runId,
+      OUTPUT_FILE: argv.out ? (argv.out as string) : "",
+      OUTPUT_TEXT: callResult.text,
+      TOOL_NAME: callResult.tool?.name,
+      TOOL_ARGS: callResult.tool?.arguments,
+      EXIT_CODE: String(callResult.exitCode)
+    });
+  }
+
+  if (callResult.needsTool) {
+    stdout.write("\n");
+    stdout.write(JSON.stringify(callResult.tool, null, 2) + "\n");
+  }
+
+  process.exit(callResult.exitCode);
+}
+
+main().catch(err => {
+  logError(err);
+  process.exit(1);
+});

--- a/provider-adapters/pai-openai/src/context.ts
+++ b/provider-adapters/pai-openai/src/context.ts
@@ -1,0 +1,87 @@
+import fg from "fast-glob";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ContextBuildOptions, ContextEntry } from "./types";
+import { log } from "./log";
+
+const DEFAULT_MAX_TOTAL = 900_000;
+const DEFAULT_MAX_FILE = 512 * 1024;
+const DEFAULT_EXTS = [
+  ".md",
+  ".txt",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".py",
+  ".rb",
+  ".go",
+  ".java"
+];
+
+export async function buildContext(options: ContextBuildOptions): Promise<{ entries: ContextEntry[]; text: string }> {
+  const maxTotal = options.maxTotalBytes ?? DEFAULT_MAX_TOTAL;
+  const maxFile = options.maxFileBytes ?? DEFAULT_MAX_FILE;
+  const includeExtensions = options.includeExtensions ?? DEFAULT_EXTS;
+  const globs = options.globs.length ? options.globs : [];
+
+  const files = globs.length
+    ? await fg(globs, {
+        dot: false,
+        unique: true,
+        ignore: ["**/node_modules/**", "**/.git/**", "**/.next/**", "**/dist/**"],
+        onlyFiles: true
+      })
+    : [];
+
+  const entries: ContextEntry[] = [];
+  let totalBytes = 0;
+
+  for (const file of files) {
+    try {
+      const stat = await fs.stat(file);
+      if (!stat.isFile()) continue;
+      if (stat.size === 0) continue;
+      const ext = path.extname(file).toLowerCase();
+      if (!includeExtensions.includes(ext)) continue;
+      if (stat.size > maxFile) {
+        log("warn", `Skipping ${file} (>${Math.round(maxFile / 1024)}KB)`);
+        continue;
+      }
+      if (totalBytes + stat.size > maxTotal) {
+        log("warn", `Context budget reached; skipping remaining files (last attempted ${file}).`);
+        break;
+      }
+      const raw = await fs.readFile(file, "utf8");
+      const truncated = Buffer.byteLength(raw, "utf8") > maxFile;
+      const text = truncated ? raw.slice(0, maxFile) : raw;
+      totalBytes += Buffer.byteLength(text, "utf8");
+      entries.push({ path: file, size: stat.size, text, truncated });
+    } catch (err) {
+      log("warn", `Failed to read context file ${file}: ${(err as Error).message}`);
+    }
+  }
+
+  if (options.stdinText) {
+    const stdin = options.stdinText.trimEnd();
+    const chunk = stdin.slice(0, maxFile);
+    const chunkBytes = Buffer.byteLength(chunk, "utf8");
+    totalBytes += chunkBytes;
+    entries.push({ path: "STDIN", size: Buffer.byteLength(stdin, "utf8"), text: chunk, truncated: chunk.length < stdin.length });
+  }
+
+  const header = `Context summary (${entries.length} sources, ${(totalBytes / 1024).toFixed(1)}KB)\n`;
+  const combined =
+    header +
+    entries
+      .map(entry => {
+        const info = `${entry.path} (${Math.round(entry.size / 1024)}KB${entry.truncated ? ", truncated" : ""})`;
+        return `\n===== ${info} =====\n${entry.text}`;
+      })
+      .join("\n");
+
+  return { entries, text: combined.slice(0, maxTotal) };
+}

--- a/provider-adapters/pai-openai/src/hooks.ts
+++ b/provider-adapters/pai-openai/src/hooks.ts
@@ -1,0 +1,22 @@
+import { spawn } from "node:child_process";
+import { HookEnv } from "./types";
+import { log } from "./log";
+
+export async function runHook(command: string, env: HookEnv) {
+  log("debug", `Running hook: ${command}`);
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: "inherit",
+      env: { ...process.env, ...env }
+    });
+    child.on("exit", code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Hook failed (${command}) with exit code ${code}`));
+      }
+    });
+    child.on("error", reject);
+  });
+}

--- a/provider-adapters/pai-openai/src/log.ts
+++ b/provider-adapters/pai-openai/src/log.ts
@@ -1,0 +1,37 @@
+import { stderr } from "node:process";
+import stripAnsi from "strip-ansi";
+import { LogLevel } from "./types";
+
+const LEVELS: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4
+};
+
+let currentLevel: LogLevel = (process.env.OPENAI_LOG_LEVEL as LogLevel) || "info";
+
+export function setLogLevel(level: LogLevel) {
+  currentLevel = level;
+}
+
+function shouldLog(level: LogLevel) {
+  return LEVELS[level] <= LEVELS[currentLevel] && currentLevel !== "silent";
+}
+
+function format(level: LogLevel, message: string) {
+  const time = new Date().toISOString();
+  const tag = level.toUpperCase().padEnd(5);
+  return `[${time}] [${tag}] ${stripAnsi(message)}`;
+}
+
+export function log(level: LogLevel, message: string) {
+  if (!shouldLog(level)) return;
+  stderr.write(format(level, message) + "\n");
+}
+
+export function logError(err: unknown) {
+  const message = err instanceof Error ? `${err.message}\n${err.stack ?? ""}` : String(err);
+  log("error", message);
+}

--- a/provider-adapters/pai-openai/src/tools.ts
+++ b/provider-adapters/pai-openai/src/tools.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ToolExecutionResult, ToolSpecFile, ToolCall } from "./types";
+import { log } from "./log";
+
+export async function loadToolSpecs(toolSpecPath?: string) {
+  if (!toolSpecPath) return undefined;
+  const absolute = path.resolve(toolSpecPath);
+  const raw = await fs.readFile(absolute, "utf8");
+  const parsed = JSON.parse(raw) as ToolSpecFile;
+  const specs = Array.isArray(parsed) ? parsed : [parsed];
+  return specs.map(spec => ({
+    type: "function" as const,
+    function: {
+      name: spec.name,
+      description: spec.description,
+      parameters: spec.parameters
+    }
+  }));
+}
+
+export async function executeTool(toolExec: string, call: ToolCall): Promise<ToolExecutionResult> {
+  const { spawn } = await import("node:child_process");
+
+  log("info", `Executing tool handler ${toolExec} for ${call.name}`);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(toolExec, {
+      shell: true,
+      stdio: ["pipe", "pipe", "inherit"],
+      env: {
+        ...process.env,
+        TOOL_NAME: call.name,
+        TOOL_ARGS: call.arguments,
+        TOOL_CALL_ID: call.id
+      }
+    });
+    let stdout = "";
+    child.stdout.on("data", chunk => {
+      stdout += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("exit", code => {
+      if (code !== 0) {
+        reject(new Error(`Tool executor exited with ${code}`));
+        return;
+      }
+      const trimmed = stdout.trim();
+      const isJson = trimmed.startsWith("{") || trimmed.startsWith("[");
+      resolve({ output: trimmed, isJson });
+    });
+    child.stdin.write(call.arguments);
+    child.stdin.end();
+  });
+}

--- a/provider-adapters/pai-openai/src/types.ts
+++ b/provider-adapters/pai-openai/src/types.ts
@@ -1,0 +1,44 @@
+export type LogLevel = "silent" | "error" | "warn" | "info" | "debug";
+
+export type ContextEntry = {
+  path: string;
+  size: number;
+  text: string;
+  truncated: boolean;
+};
+
+export type ContextBuildOptions = {
+  globs: string[];
+  stdinText?: string;
+  maxTotalBytes?: number;
+  maxFileBytes?: number;
+  includeExtensions?: string[];
+};
+
+export type ToolCall = {
+  id: string;
+  name: string;
+  arguments: string;
+};
+
+export type CallResult = {
+  exitCode: number;
+  text: string;
+  needsTool: boolean;
+  tool?: ToolCall;
+};
+
+export type HookEnv = Record<string, string | undefined>;
+
+export type ToolSpec = {
+  name: string;
+  description?: string;
+  parameters?: unknown;
+};
+
+export type ToolSpecFile = ToolSpec | ToolSpec[];
+
+export type ToolExecutionResult = {
+  output: string;
+  isJson: boolean;
+};

--- a/provider-adapters/pai-openai/tests/context.test.ts
+++ b/provider-adapters/pai-openai/tests/context.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="vitest" />
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { buildContext } from "../src/context";
+
+async function setupFixture() {
+  const dir = await fs.mkdtemp(path.join(tmpdir(), "pai-openai-context-"));
+  const files = {
+    "readme.md": "Hello world", // allowed
+    "notes.txt": "Second file", // allowed
+    "image.png": "binary?", // skipped by extension
+    "big.ts": "export const data = \"" + "x".repeat(1024) + "\";"
+  } as Record<string, string>;
+
+  await Promise.all(
+    Object.entries(files).map(async ([name, contents]) => {
+      await fs.writeFile(path.join(dir, name), contents, "utf8");
+    })
+  );
+
+  return dir;
+}
+
+describe("buildContext", () => {
+  it("collects matching files and summarizes context", async () => {
+    const dir = await setupFixture();
+    const { entries, text } = await buildContext({
+      globs: [path.join(dir, "**/*")],
+      maxTotalBytes: 20_000,
+      maxFileBytes: 2_048
+    });
+
+    expect(entries.map(e => e.path).sort()).toContain(path.join(dir, "notes.txt"));
+    expect(entries.map(e => e.path).sort()).toContain(path.join(dir, "readme.md"));
+    expect(entries.find(e => e.path.endsWith("image.png"))).toBeUndefined();
+    expect(text).toMatch(/Context summary/);
+    expect(text).toMatch(/===== .*readme\.md/);
+  });
+
+  it("appends STDIN content and respects file truncation", async () => {
+    const dir = await setupFixture();
+    const { entries } = await buildContext({
+      globs: [path.join(dir, "**/*")],
+      maxTotalBytes: 4_096,
+      maxFileBytes: 128,
+      stdinText: "streamed input"
+    });
+
+    const bigEntry = entries.find(e => e.path.endsWith("big.ts"));
+    expect(bigEntry).toBeDefined();
+    expect(bigEntry?.truncated).toBe(true);
+    expect(bigEntry?.text.length).toBe(128);
+
+    const stdinEntry = entries.find(e => e.path === "STDIN");
+    expect(stdinEntry).toBeDefined();
+    expect(stdinEntry?.text).toBe("streamed input");
+  });
+});

--- a/provider-adapters/pai-openai/tests/hooks.test.ts
+++ b/provider-adapters/pai-openai/tests/hooks.test.ts
@@ -1,0 +1,23 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it } from "vitest";
+import { runHook } from "../src/hooks";
+
+const nodeBinary = process.execPath;
+
+describe("runHook", () => {
+  it("runs hook command with injected environment", async () => {
+    await expect(
+      runHook(
+        `${nodeBinary} -e "if (process.env.TEST_VALUE !== 'ok') { process.exit(1); }"`,
+        { TEST_VALUE: "ok" }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when hook exits with non-zero status", async () => {
+    await expect(
+      runHook(`${nodeBinary} -e "process.exit(3)"`, {})
+    ).rejects.toThrow(/exit code 3/);
+  });
+});

--- a/provider-adapters/pai-openai/tests/log.test.ts
+++ b/provider-adapters/pai-openai/tests/log.test.ts
@@ -1,0 +1,35 @@
+/// <reference types="vitest" />
+
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { log, logError, setLogLevel } from "../src/log";
+
+describe("log", () => {
+  let spy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    setLogLevel("debug");
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    setLogLevel("info");
+  });
+
+  it("writes messages at or above the current level", () => {
+    log("info", "message");
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("[INFO ]"));
+  });
+
+  it("suppresses messages below the current level", () => {
+    setLogLevel("error");
+    log("warn", "should not appear");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("logs error stacks via logError", () => {
+    const error = new Error("boom");
+    logError(error);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("boom"));
+  });
+});

--- a/provider-adapters/pai-openai/tests/tools.test.ts
+++ b/provider-adapters/pai-openai/tests/tools.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="vitest" />
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { executeTool, loadToolSpecs } from "../src/tools";
+
+const nodeBinary = process.execPath;
+
+describe("loadToolSpecs", () => {
+  it("reads a tool schema file and normalizes to OpenAI format", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "pai-openai-tools-"));
+    const file = path.join(dir, "spec.json");
+    await fs.writeFile(
+      file,
+      JSON.stringify({ name: "whoami", description: "Describe user", parameters: { type: "object" } }),
+      "utf8"
+    );
+
+    const specs = await loadToolSpecs(file);
+    expect(specs).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "whoami",
+          description: "Describe user",
+          parameters: { type: "object" }
+        }
+      }
+    ]);
+  });
+});
+
+describe("executeTool", () => {
+  it("streams tool args to the executor and returns JSON metadata", async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), "pai-openai-tool-exec-"));
+    const script = path.join(dir, "tool.js");
+    await fs.writeFile(
+      script,
+      [
+        "let input = '';",
+        "process.stdin.setEncoding('utf8');",
+        "process.stdin.on('data', chunk => input += chunk);",
+        "process.stdin.on('end', () => {",
+        "  if (process.env.TOOL_NAME !== 'whoami') process.exit(2);",
+        "  const payload = { input: input.trim(), id: process.env.TOOL_CALL_ID };",
+        "  process.stdout.write(JSON.stringify(payload));",
+        "  process.exit(0);",
+        "});"
+      ].join("\n"),
+      "utf8"
+    );
+
+    const result = await executeTool(`${nodeBinary} ${script}`, {
+      id: "call-123",
+      name: "whoami",
+      arguments: '{"hello":"world"}'
+    });
+
+    expect(result.isJson).toBe(true);
+    expect(JSON.parse(result.output)).toEqual({ input: '{"hello":"world"}', id: "call-123" });
+  });
+});

--- a/provider-adapters/pai-openai/tsconfig.json
+++ b/provider-adapters/pai-openai/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "strict": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/provider-adapters/pai-openai/vitest.config.ts
+++ b/provider-adapters/pai-openai/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    globals: true,
+    coverage: {
+      reporter: ["text", "lcov"],
+      reportsDirectory: "coverage"
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a new provider-adapters/pai-openai TypeScript project that ships the `pai-openai` CLI
- implement filesystem context ingestion, hook execution, streaming OpenAI Responses support, and tool-call handling
- add logging utilities, tool schema loading, and packaging metadata for distribution
- introduce a Vitest configuration and unit tests covering context ingestion, hooks, logging, and tool execution helpers

## Testing
- npm test --prefix provider-adapters/pai-openai *(fails in container: vitest binary unavailable until dependencies are installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d77a5fdc832884a06775bdfebe41