### PR TITLE
Add agent instructions for PAI and OpenAI adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# PAI Agent Instructions
+
+## Project overview
+PAI (Personal AI Infrastructure) is an open-source framework for orchestrating personal and professional workflows with AI. The repository collects the core configuration, shared tooling, and provider-specific adapters that let PAI connect large language models to local context, automation hooks, and custom tools.
+
+## Provider adapters
+- `provider-adapters/pai-openai`: A TypeScript CLI wrapper around OpenAI's Responses API that enriches prompts with repository context, streams responses, and executes declared tool calls.

--- a/provider-adapters/pai-openai/AGENTS.md
+++ b/provider-adapters/pai-openai/AGENTS.md
@@ -1,0 +1,9 @@
+# PAI OpenAI Adapter Agent Instructions
+
+## Architecture and purpose
+The `pai-openai` package is a TypeScript CLI that wraps OpenAI's Responses API for use inside PAI workflows. `src/cli.ts` is the entrypoint that parses flags with Yargs, builds repository context via `context.ts`, orchestrates pre/post hooks from `hooks.ts`, and delegates API calls to `adapter.ts`. The adapter streams or batches responses, enforces JSON mode when requested, and brokers tool execution through `tools.ts`. Shared types live in `types.ts`, while `log.ts` centralizes structured logging.
+
+## Development guidelines
+- Always use concrete, well-defined TypeScript types. Prefer explicit interfaces, discriminated unions, and helper generics instead of `any` or overly loose structural typing.
+- Run linting before every commit: `npm run lint`.
+- Run tests before every commit: `npm test` (or `npm run test`).


### PR DESCRIPTION
## Summary
- add a repository-level AGENTS.md describing the PAI project and enumerating available adapters
- add adapter-specific AGENTS.md detailing the pai-openai architecture and coding guidelines

## Testing
- `npm run lint` *(fails: ESLint 9 requires eslint.config.js and none is present)*
- `npm test` *(fails: tests/context.test.ts expects truncated big.ts context entry)*

------
https://chatgpt.com/codex/tasks/task_e_68e4dbfdc8d48328b16ed674f37e3f0e